### PR TITLE
fix: 修复 Web UI 中文输入法回车误发送消息 (macOS)

### DIFF
--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -2255,7 +2255,7 @@ export default function ChatView() {
       setEditingMessageId(null);
       return;
     }
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !(e.nativeEvent as KeyboardEvent).isComposing) {
       e.preventDefault();
       if (uploadingCount === 0 && (input.trim() || pendingImages.length > 0 || pendingFiles.length > 0)) handleSend();
     }

--- a/web/src/components/office/overlay/MessageInput.tsx
+++ b/web/src/components/office/overlay/MessageInput.tsx
@@ -34,7 +34,7 @@ export default function MessageInput() {
     <div className="absolute bottom-28 right-2 w-80 z-20">
       <div className="bg-bg-primary/95 backdrop-blur-sm rounded-lg border border-border-default px-3 py-2 flex items-center gap-2 shadow-lg">
         <span className="text-[10px] text-text-tertiary shrink-0">@{targetName}</span>
-        <input ref={inputRef} type="text" value={message} onChange={(e) => setMessage(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend(); } }} placeholder={t('office.sendMessage','Send message...')} className="flex-1 rounded-md border border-border-input bg-bg-input px-2 py-1 text-sm text-text-primary placeholder:text-text-tertiary outline-none" disabled={sending} />
+        <input ref={inputRef} type="text" value={message} onChange={(e) => setMessage(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) { e.preventDefault(); handleSend(); } }} placeholder={t('office.sendMessage','Send message...')} className="flex-1 rounded-md border border-border-input bg-bg-input px-2 py-1 text-sm text-text-primary placeholder:text-text-tertiary outline-none" disabled={sending} />
         <button onClick={handleSend} disabled={!message.trim() || sending} className="p-1 rounded hover:bg-bg-secondary text-accent-brand disabled:opacity-30"><Send size={14} /></button>
       </div>
     </div>


### PR DESCRIPTION
## 问题

中文输入法（IME）组合状态下按回车确认候选词时，直接触发消息发送，导致用户尚未完成输入就被发出。

> ⚠️ **注意**：此问题可能是 macOS 端独有，macOS 的中文输入法（如拼音输入法）在 IME 组合状态下 `isComposing` 行为与 Windows/Linux 存在差异，建议在各平台回归测试。

## 根因

`ChatView.tsx` 和 `MessageInput.tsx` 的 Enter keydown 处理缺少 `isComposing` 守卫，IME 组合期间的回车被误判为发送。

## 修复内容

在两处 Enter 判断中增加 `!(e.nativeEvent as KeyboardEvent).isComposing` 条件：

| 文件 | 行号 | 改动 |
|---|---|---|
| `web/src/components/chat/ChatView.tsx` | 2258 | `!e.shiftKey` → `!e.shiftKey && !(e.nativeEvent as KeyboardEvent).isComposing` |
| `web/src/components/office/overlay/MessageInput.tsx` | 37 | `!e.shiftKey` → `!e.shiftKey && !e.nativeEvent.isComposing` |

## 影响面分析

- 仅 2 个文件各 1 行改动
- 全局搜索确认无其他 `isComposing` 匹配
- 不改变 `handleSend` 调用签名、组件 props、API 调用链路
- 不影响其他 `onKeyDown` + `Enter` 场景（搜索框、重命名、BranchPanel 等）

## 边界正确性

- `isComposing === true` → Enter 被忽略，浏览器正常完成 IME 确认 ✓
- `isComposing === false` → 行为与改动前完全一致 ✓
- `Shift+Enter` 换行 → 不受影响 ✓
- 非 IME 用户 → `isComposing` 始终 `false`，零行为变化 ✓

## 验证

- ✅ TypeScript 编译零错误
- ✅ 本地验证（macOS）：中文输入法回车确认候选词不再误发送消息