### PR TITLE
feat(web): Docs 中英文支持 + 模型测试连接 + MCP 内联表单 + 设置页侧边栏粘性定位

### DIFF
--- a/src/web-server/MiscRoutes.ts
+++ b/src/web-server/MiscRoutes.ts
@@ -75,57 +75,87 @@ function compareVersions(a: string, b: string): number {
 
 const builtinDocs = [
   {
-    id: 'getting-started', title: 'Getting Started',
+    id: 'getting-started', title: 'Getting Started', titleZh: '快速入门',
     content: 'Welcome to Lingxiao (凌霄剑域). Lingxiao is a multi-agent coding assistant with a TUI and Web UI.\n\nRun `lingxiao` to launch, then open the Web UI in your browser.\n\nUse the sidebar to navigate between views: Chat, Editor, Canvas, Terminal, Traces, Workers, and more.',
+    contentZh: '欢迎使用凌霄剑域（Lingxiao）。凌霄是一个支持 TUI 与 Web UI 的多智能体编程助手。\n\n运行 `lingxiao` 启动，然后在浏览器中打开 Web UI。\n\n使用侧边栏在各视图之间切换：对话、编辑器、画布、终端、追踪、工作线程等。',
     children: [
-      { id: 'installation', title: 'Installation', content: '```bash\nnpm install -g lingxiao\nlingxiao\n```\n\nThe Web UI will be available at `http://localhost:8080`.' },
-      { id: 'configuration', title: 'Configuration', content: 'Settings are stored in `~/.lingxiao/settings.json`. Use the Settings view in the Web UI or the `/config` command in TUI.\n\nKey settings:\n- `llm.provider` — LLM provider (openai, anthropic, auto)\n- `llm.leader_model` — Model for the leader agent\n- `llm.enable_extended_thinking` — Enable deep thinking mode' },
+      { id: 'installation', title: 'Installation', titleZh: '安装',
+        content: '```bash\nnpm install -g lingxiao\nlingxiao\n```\n\nThe Web UI will be available at `http://localhost:8080`.',
+        contentZh: '```bash\nnpm install -g lingxiao\nlingxiao\n```\n\nWeb UI 将在 `http://localhost:8080` 可用。' },
+      { id: 'configuration', title: 'Configuration', titleZh: '配置',
+        content: 'Settings are stored in `~/.lingxiao/settings.json`. Use the Settings view in the Web UI or the `/config` command in TUI.\n\nKey settings:\n- `llm.provider` — LLM provider (openai, anthropic, auto)\n- `llm.leader_model` — Model for the leader agent\n- `llm.enable_extended_thinking` — Enable deep thinking mode',
+        contentZh: '设置存储在 `~/.lingxiao/settings.json`。使用 Web UI 中的设置视图或 TUI 中的 `/config` 命令进行修改。\n\n关键设置：\n- `llm.provider` — LLM 提供商（openai、anthropic、auto）\n- `llm.leader_model` — 主智能体使用的模型\n- `llm.enable_extended_thinking` — 启用深度思考模式' },
     ],
   },
   {
-    id: 'chat', title: 'Chat View',
+    id: 'chat', title: 'Chat View', titleZh: '对话视图',
     content: 'The Chat view is the primary interface for interacting with the AI assistant. Type your message and press Enter to send.\n\nMessages support markdown rendering including code blocks, tables, and thinking content.',
+    contentZh: '对话视图是与 AI 助手交互的主要界面。输入消息并按回车发送。\n\n消息支持 Markdown 渲染，包括代码块、表格和思考内容。',
     children: [
-      { id: 'deep-thinking', title: 'Deep Thinking', content: 'Toggle the **sparkles** button in the chat input bar to enable extended thinking mode.\n\nWhen enabled, the model will show its reasoning process in a collapsible "Thinking" block before the response.' },
-      { id: 'permissions', title: 'Permissions', content: 'When the AI requests permission to execute a tool (e.g., file write, shell command), an approval banner appears at the bottom of the chat.\n\nYou can approve or deny each request. Approved permissions are shown in the Permission History section.' },
-      { id: 'file-upload', title: 'File Upload', content: 'Click the **paperclip** button in the chat input to attach files. Files are uploaded to the server and included in the conversation context.' },
+      { id: 'deep-thinking', title: 'Deep Thinking', titleZh: '深度思考',
+        content: 'Toggle the **sparkles** button in the chat input bar to enable extended thinking mode.\n\nWhen enabled, the model will show its reasoning process in a collapsible "Thinking" block before the response.',
+        contentZh: '点击聊天输入栏中的 **✨** 按钮启用深度思考模式。\n\n启用后，模型会在回复前以可折叠的"思考"块展示推理过程。' },
+      { id: 'permissions', title: 'Permissions', titleZh: '权限管理',
+        content: 'When the AI requests permission to execute a tool (e.g., file write, shell command), an approval banner appears at the bottom of the chat.\n\nYou can approve or deny each request. Approved permissions are shown in the Permission History section.',
+        contentZh: '当 AI 请求执行工具（如文件写入、Shell 命令）的权限时，聊天底部会弹出审批横幅。\n\n你可以批准或拒绝每个请求。已批准的权限显示在权限历史区域。' },
+      { id: 'file-upload', title: 'File Upload', titleZh: '文件上传',
+        content: 'Click the **paperclip** button in the chat input to attach files. Files are uploaded to the server and included in the conversation context.',
+        contentZh: '点击聊天输入栏中的**回形针**按钮来附加文件。文件会上传到服务器并纳入对话上下文。' },
     ],
   },
   {
-    id: 'canvas', title: 'Canvas & Workflow',
+    id: 'canvas', title: 'Canvas & Workflow', titleZh: '画布与工作流',
     content: 'The Canvas view provides a visual workflow editor using drag-and-drop nodes.\n\n**Right-click** on the canvas to add nodes. **Right-click** on a node for actions like Run, Connect, Edit, and Delete.',
+    contentZh: '画布视图提供了拖拽式可视化工作流编辑器。\n\n**右键**画布添加节点。**右键**节点可执行运行、连接、编辑、删除等操作。',
     children: [
-      { id: 'node-types', title: 'Node Types', content: '- **Agent** — Represents an AI agent that can execute tasks\n- **Tool** — Represents a tool/function call\n- **Condition** — Branching logic node\n- **Input/Output** — Data flow entry/exit points\n\nThe Leader node automatically appears when a session is active and syncs with the real agent status.' },
-      { id: 'canvas-actions', title: 'Canvas Actions', content: '- **Right-click canvas** — Add node, Fit view, Reset\n- **Right-click node** — Run, Connect to, Edit, Mark complete/paused, Delete\n- **Drag** nodes to rearrange\n- **Scroll** to zoom\n- **Drag canvas** to pan' },
+      { id: 'node-types', title: 'Node Types', titleZh: '节点类型',
+        content: '- **Agent** — Represents an AI agent that can execute tasks\n- **Tool** — Represents a tool/function call\n- **Condition** — Branching logic node\n- **Input/Output** — Data flow entry/exit points\n\nThe Leader node automatically appears when a session is active and syncs with the real agent status.',
+        contentZh: '- **Agent** — AI 智能体节点，可执行任务\n- **Tool** — 工具/函数调用节点\n- **Condition** — 分支逻辑节点\n- **Input/Output** — 数据流入口/出口节点\n\n当会话活跃时，Leader 节点会自动出现并与真实智能体状态同步。' },
+      { id: 'canvas-actions', title: 'Canvas Actions', titleZh: '画布操作',
+        content: '- **Right-click canvas** — Add node, Fit view, Reset\n- **Right-click node** — Run, Connect to, Edit, Mark complete/paused, Delete\n- **Drag** nodes to rearrange\n- **Scroll** to zoom\n- **Drag canvas** to pan',
+        contentZh: '- **右键画布** — 添加节点、自适应视图、重置\n- **右键节点** — 运行、连接、编辑、标记完成/暂停、删除\n- **拖拽**节点重新排列\n- **滚轮**缩放\n- **拖拽画布**平移' },
     ],
   },
   {
-    id: 'terminal', title: 'Terminal',
+    id: 'terminal', title: 'Terminal', titleZh: '终端',
     content: 'The Terminal view provides an interactive shell via WebSocket. Commands run in the project workspace.\n\nThe terminal supports full interactivity including colors, cursor movement, and resize.',
+    contentZh: '终端视图通过 WebSocket 提供交互式 Shell。命令在项目工作空间中运行。\n\n终端支持完整的交互功能，包括颜色、光标移动和窗口缩放。',
   },
   {
-    id: 'editor', title: 'Editor',
+    id: 'editor', title: 'Editor', titleZh: '编辑器',
     content: 'The Editor view is a VS Code-powered code editor using Monaco Editor.\n\nFeatures:\n- Full syntax highlighting for 50+ languages\n- File tree browser with create/delete support\n- Ctrl+S to save\n- Image preview\n- Multiple open tabs',
+    contentZh: '编辑器视图是基于 Monaco Editor 的 VS Code 风格代码编辑器。\n\n功能特性：\n- 50+ 语言的完整语法高亮\n- 支持创建/删除的文件树浏览器\n- Ctrl+S 保存\n- 图片预览\n- 多标签页打开',
     children: [
-      { id: 'editor-shortcuts', title: 'Keyboard Shortcuts', content: '| Shortcut | Action |\n|----------|--------|\n| Ctrl+S | Save file |\n| Ctrl+P | Quick open |\n| Ctrl+Shift+P | Command palette |\n| Ctrl+G | Go to line |' },
+      { id: 'editor-shortcuts', title: 'Keyboard Shortcuts', titleZh: '快捷键',
+        content: '| Shortcut | Action |\n|----------|--------|\n| Ctrl+S | Save file |\n| Ctrl+P | Quick open |\n| Ctrl+Shift+P | Command palette |\n| Ctrl+G | Go to line |',
+        contentZh: '| 快捷键 | 功能 |\n|----------|--------|\n| Ctrl+S | 保存文件 |\n| Ctrl+P | 快速打开 |\n| Ctrl+Shift+P | 命令面板 |\n| Ctrl+G | 跳转到行 |' },
     ],
   },
   {
-    id: 'api', title: 'API Reference',
+    id: 'api', title: 'API Reference', titleZh: 'API 参考',
     content: 'Lingxiao exposes a REST API at `/api/v1/` and an ACP protocol for real-time communication.',
+    contentZh: '凌霄在 `/api/v1/` 暴露 REST API，并通过 ACP 协议进行实时通信。',
     children: [
-      { id: 'acp-protocol', title: 'ACP Protocol', content: 'The Agent Communication Protocol uses **SSE + JSON-RPC**.\n\n1. `POST /api/v1/acp/connect` — Establish connection, get session token\n2. `GET /api/v1/acp` — Subscribe to SSE events\n3. `POST /api/v1/acp` — Send JSON-RPC commands\n\nKey JSON-RPC methods: `session/prompt`, `session/cancel`, `_lingxiao.ai/getUserInfo`' },
-      { id: 'rest-api', title: 'REST API', content: 'All REST endpoints require the `x-lingxiao-request: 1` header.\n\n| Endpoint | Description |\n|----------|-------------|\n| `GET /api/v1/info` | System information |\n| `GET /api/v1/settings` | Read settings |\n| `PUT /api/v1/settings/:group` | Update setting |\n| `GET /api/v1/workers` | Active workers |\n| `GET /api/v1/plugins` | Installed plugins |\n| `GET /api/v1/stats` | Usage statistics |' },
-      { id: 'storage', title: 'Storage KV', content: 'Persistent key-value storage via:\n- `GET /api/v1/storage` — List keys\n- `PUT /api/v1/storage` — Set value\n- `DELETE /api/v1/storage/:id` — Delete key\n\nSupports `key`, `namespace`, and `scope` parameters.' },
+      { id: 'acp-protocol', title: 'ACP Protocol', titleZh: 'ACP 协议',
+        content: 'The Agent Communication Protocol uses **SSE + JSON-RPC**.\n\n1. `POST /api/v1/acp/connect` — Establish connection, get session token\n2. `GET /api/v1/acp` — Subscribe to SSE events\n3. `POST /api/v1/acp` — Send JSON-RPC commands\n\nKey JSON-RPC methods: `session/prompt`, `session/cancel`, `_lingxiao.ai/getUserInfo`',
+        contentZh: 'Agent Communication Protocol 基于 **SSE + JSON-RPC**。\n\n1. `POST /api/v1/acp/connect` — 建立连接，获取会话 token\n2. `GET /api/v1/acp` — 订阅 SSE 事件\n3. `POST /api/v1/acp` — 发送 JSON-RPC 命令\n\n常用 JSON-RPC 方法：`session/prompt`、`session/cancel`、`_lingxiao.ai/getUserInfo`' },
+      { id: 'rest-api', title: 'REST API', titleZh: 'REST API',
+        content: 'All REST endpoints require the `x-lingxiao-request: 1` header.\n\n| Endpoint | Description |\n|----------|-------------|\n| `GET /api/v1/info` | System information |\n| `GET /api/v1/settings` | Read settings |\n| `PUT /api/v1/settings/:group` | Update setting |\n| `GET /api/v1/workers` | Active workers |\n| `GET /api/v1/plugins` | Installed plugins |\n| `GET /api/v1/stats` | Usage statistics |',
+        contentZh: '所有 REST 端点需要 `x-lingxiao-request: 1` 请求头。\n\n| 端点 | 描述 |\n|----------|-------------|\n| `GET /api/v1/info` | 系统信息 |\n| `GET /api/v1/settings` | 读取设置 |\n| `PUT /api/v1/settings/:group` | 更新设置 |\n| `GET /api/v1/workers` | 活跃工作线程 |\n| `GET /api/v1/plugins` | 已安装插件 |\n| `GET /api/v1/stats` | 使用统计 |' },
+      { id: 'storage', title: 'Storage KV', titleZh: 'KV 存储',
+        content: 'Persistent key-value storage via:\n- `GET /api/v1/storage` — List keys\n- `PUT /api/v1/storage` — Set value\n- `DELETE /api/v1/storage/:id` — Delete key\n\nSupports `key`, `namespace`, and `scope` parameters.',
+        contentZh: '持久化键值存储接口：\n- `GET /api/v1/storage` — 列出键\n- `PUT /api/v1/storage` — 设置值\n- `DELETE /api/v1/storage/:id` — 删除键\n\n支持 `key`、`namespace` 和 `scope` 参数。' },
     ],
   },
   {
-    id: 'traces', title: 'Traces',
+    id: 'traces', title: 'Traces', titleZh: '追踪',
     content: 'The Traces view shows agent execution traces with 4 visualization modes:\n\n1. **Timeline** — Chronological list of events\n2. **Tree** — Hierarchical view of agent-tool relationships\n3. **Flame** — Duration-based visualization\n4. **Graph** — DAG layout of spans\n\nTraces are loaded from the session\'s agent logs and updated in real-time via SSE.',
+    contentZh: '追踪视图以 4 种可视化模式展示智能体执行追踪：\n\n1. **时间线** — 按时间顺序列出事件\n2. **树形图** — 智能体-工具关系的层级视图\n3. **火焰图** — 基于时长的可视化\n4. **拓扑图** — DAG 布局的 Span 视图\n\n追踪数据从会话的智能体日志加载，并通过 SSE 实时更新。',
   },
   {
-    id: 'keyboard', title: 'Keyboard Shortcuts',
+    id: 'keyboard', title: 'Keyboard Shortcuts', titleZh: '快捷键',
     content: 'Use `Ctrl+Shift+P` to open the command palette.\n\nSee the Keybindings view for all available keyboard shortcuts.',
+    contentZh: '使用 `Ctrl+Shift+P` 打开命令面板。\n\n查看快捷键视图了解所有可用快捷键。',
   },
 ];
 
@@ -255,7 +285,7 @@ export function registerMiscRoutes(
             if (titleMatch) title = titleMatch[1].trim();
             body = content.slice(fmMatch[0].length);
           }
-          loaded.push({ id, title, content: body.trim() });
+          loaded.push({ id, title, titleZh: title, content: body.trim(), contentZh: body.trim() });
         }
         if (loaded.length > 0) {
           cachedDocs = loaded;

--- a/src/web-server/SettingsRoutes.ts
+++ b/src/web-server/SettingsRoutes.ts
@@ -859,6 +859,75 @@ export function registerSettingsRoutes(
   });
 
 
+  // POST /api/v1/settings/test-model-provider/:id — 用已保存的模型配置测试连接
+  fastify.post('/api/v1/settings/test-model-provider/:id', async (request, reply) => {
+    if (!requireServerToken(request, reply)) return;
+    const { id } = request.params as { id: string };
+    if (!id) {
+      reply.status(400).send({ error: 'id is required' });
+      return;
+    }
+    const providers = getConfigValue('llm.model_providers') as ModelProvidersConfig | undefined;
+    if (!providers) {
+      reply.status(404).send({ error: 'No model providers configured' });
+      return;
+    }
+    let found: { provider: string; apiKey: string; baseUrl: string; model: string } | null = null;
+    for (const [providerKey, models] of Object.entries(providers)) {
+      const list = Array.isArray(models) ? models : [];
+      const match = list.find((m) => m?.id === id || m?.name === id);
+      if (match) {
+        found = { provider: providerKey, apiKey: String(match.apiKey ?? ''), baseUrl: String(match.baseUrl ?? ''), model: String(match.model ?? match.id ?? '') };
+        break;
+      }
+    }
+    if (!found || !found.apiKey) {
+      reply.status(404).send({ error: `Model '${id}' not found or has no API key` });
+      return;
+    }
+    try {
+      const isAnthropic = found.provider === 'anthropic';
+      const defaultBaseUrl = isAnthropic ? 'https://api.anthropic.com' : 'https://api.openai.com/v1';
+      const effectiveBaseUrl = found.baseUrl || defaultBaseUrl;
+      const url = isAnthropic
+        ? `${effectiveBaseUrl.replace(/\/$/, '')}/v1/messages`
+        : `${effectiveBaseUrl.replace(/\/$/, '')}/chat/completions`;
+      const headers: Record<string, string> = isAnthropic
+        ? { 'x-api-key': found.apiKey, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' }
+        : { 'authorization': `Bearer ${found.apiKey}`, 'content-type': 'application/json' };
+      const payload = {
+        model: found.model,
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'Hi' }],
+      };
+      const llmRes = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (llmRes.ok) {
+        const data = await llmRes.json() as { content?: Array<{ text?: string }>; choices?: Array<{ message?: { content?: string } }> };
+        const preview = isAnthropic
+          ? (data.content?.[0]?.text || '').slice(0, 100)
+          : (data.choices?.[0]?.message?.content || '').slice(0, 100);
+        return { success: true, data: { message: 'Connection successful', responsePreview: preview } };
+      }
+      const errText = await llmRes.text().catch(() => '');
+      let errMsg = `HTTP ${llmRes.status}`;
+      try {
+        const errJson = JSON.parse(errText);
+        errMsg = errJson?.error?.message || errJson?.error || errJson?.message || errMsg;
+      } catch {
+        if (errText) errMsg = errText.slice(0, 200);
+      }
+      reply.status(502).send({ error: `${errMsg} (status ${llmRes.status})` });
+    } catch (e: unknown) {
+      request.log.warn({ err: e }, 'test-model-provider failed');
+      reply.status(502).send({ error: toErrorMessage(e) });
+    }
+  });
+
   // POST /api/v1/settings/model-provider — 添加模型提供者
   fastify.post('/api/v1/settings/model-provider', async (request, reply) => {
     if (!requireServerToken(request, reply)) return;

--- a/web/src/components/docs/DocsView.tsx
+++ b/web/src/components/docs/DocsView.tsx
@@ -16,7 +16,9 @@ import {
 interface DocSection {
   id: string;
   title: string;
+  titleZh: string;
   content: string;
+  contentZh: string;
   children?: DocSection[];
 }
 
@@ -28,7 +30,9 @@ function normalizeDocSection(value: unknown): DocSection | null {
   if (!isRecord(value)) return null;
   const id = typeof value.id === 'string' ? value.id.trim() : '';
   const title = typeof value.title === 'string' ? value.title.trim() : '';
+  const titleZh = typeof value.titleZh === 'string' ? value.titleZh.trim() : title;
   const content = typeof value.content === 'string' ? value.content : '';
+  const contentZh = typeof value.contentZh === 'string' ? value.contentZh : content;
   if (!id || !title) return null;
 
   if (value.children !== undefined && !Array.isArray(value.children)) return null;
@@ -38,7 +42,9 @@ function normalizeDocSection(value: unknown): DocSection | null {
   return {
     id,
     title,
+    titleZh,
     content,
+    contentZh,
     ...(children.length > 0 ? { children } : {}),
   };
 }
@@ -70,8 +76,10 @@ function firstSectionId(sections: DocSection[]): string {
 }
 
 export default function DocsView() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const isZh = i18n.language === 'zh';
   const [docs, setDocs] = useState<DocSection[]>([]);
+
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [activeSection, setActiveSection] = useState<string>('');
   const [search, setSearch] = useState('');
@@ -116,9 +124,12 @@ export default function DocsView() {
 
   const filterSections = (sections: DocSection[], query: string): DocSection[] => {
     if (!query) return sections;
+    const q = query.toLowerCase();
     return sections.filter((s) =>
-      s.title.toLowerCase().includes(query.toLowerCase()) ||
-      s.content.toLowerCase().includes(query.toLowerCase()) ||
+      s.title.toLowerCase().includes(q) ||
+      s.titleZh.toLowerCase().includes(q) ||
+      s.content.toLowerCase().includes(q) ||
+      s.contentZh.toLowerCase().includes(q) ||
       (s.children && filterSections(s.children, query).length > 0)
     );
   };
@@ -142,7 +153,7 @@ export default function DocsView() {
               {expanded.has(section.id) ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
             </span>
           )}
-          <span className="truncate">{section.title}</span>
+          <span className="truncate">{isZh ? section.titleZh : section.title}</span>
         </button>
         {section.children && expanded.has(section.id) && renderToc(section.children, depth + 1)}
       </div>
@@ -156,7 +167,7 @@ export default function DocsView() {
         <div className="px-3 py-2 border-b border-border-default">
           <div className="flex items-center gap-2 mb-2">
             <BookOpen className="w-4 h-4 text-text-tertiary" />
-            <span className="text-sm font-medium text-text-primary">{t('docs.toc')}</span>
+            <span className="text-sm font-medium text-text-primary flex-1">{t('docs.toc')}</span>
           </div>
           <div className="relative">
             <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-tertiary" />
@@ -210,9 +221,9 @@ export default function DocsView() {
           </div>
         ) : active ? (
           <article>
-            <h1 className="text-xl font-semibold text-text-primary mb-4">{active.title}</h1>
-            <div className="prose prose-sm prose-invert max-w-none text-text-secondary">
-              <SafeMarkdown>{active.content}</SafeMarkdown>
+            <h1 className="text-xl font-semibold text-text-primary mb-4">{isZh ? active.titleZh : active.title}</h1>
+            <div className="docs-prose max-w-none">
+              <SafeMarkdown>{isZh ? active.contentZh : active.content}</SafeMarkdown>
             </div>
             {active.children && (
               <div className="mt-6 space-y-4">
@@ -222,10 +233,10 @@ export default function DocsView() {
                       className="text-base font-medium text-text-primary mb-2 cursor-pointer hover:text-accent-brand"
                       onClick={() => setActiveSection(child.id)}
                     >
-                      {child.title}
+                      {isZh ? child.titleZh : child.title}
                     </h2>
-                    <div className="prose prose-sm prose-invert max-w-none text-text-secondary">
-                      <SafeMarkdown>{child.content}</SafeMarkdown>
+                    <div className="docs-prose max-w-none">
+                      <SafeMarkdown>{isZh ? child.contentZh : child.content}</SafeMarkdown>
                     </div>
                   </section>
                 ))}

--- a/web/src/components/plugins/McpServerForm.tsx
+++ b/web/src/components/plugins/McpServerForm.tsx
@@ -42,6 +42,7 @@ interface Props {
   initial?: McpServerConfig;
   onClose: () => void;
   onSaved: (server: McpServerConfig) => void;
+  inline?: boolean;
 }
 
 const ID_RE = /^[a-z][a-z0-9_]{1,79}$/;
@@ -132,7 +133,7 @@ async function saveServer(payload: McpServerConfig): Promise<McpServerConfig> {
   return body.data as McpServerConfig;
 }
 
-export default function McpServerForm({ initial, onClose, onSaved }: Props) {
+export default function McpServerForm({ initial, onClose, onSaved, inline }: Props) {
   const { t } = useTranslation();
   const isEdit = Boolean(initial);
   const [server, setServer] = useState<McpServerConfig>(() => initial ? { ...initial } : emptyServer());
@@ -279,8 +280,8 @@ export default function McpServerForm({ initial, onClose, onSaved }: Props) {
   };
 
   return (
-    <div className="lx-overlay p-4">
-      <div className="bg-bg-primary border border-border-default rounded-lg w-full max-w-3xl max-h-[90vh] flex flex-col">
+    <div className={inline ? '' : 'lx-overlay p-4'}>
+      <div className={`bg-bg-primary border border-border-default rounded-lg w-full flex flex-col ${inline ? '' : 'max-w-3xl max-h-[90vh]'}`}>
         <div className="px-4 py-3 border-b border-border-default flex items-center justify-between">
           <h3 className="text-sm font-medium text-text-primary">
             {isEdit ? t('mcp.form.editTitle') : t('mcp.form.addTitle')}

--- a/web/src/components/plugins/McpServersTab.tsx
+++ b/web/src/components/plugins/McpServersTab.tsx
@@ -6,11 +6,12 @@ import McpServerForm, { type McpServerConfig } from './McpServerForm';
 import { useSessionStore } from '../../stores/sessionStore';
 
 async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> {
+  const hasBody = opts?.body != null;
   const res = await fetch(`/api/v1${path}`, {
     ...opts,
     cache: 'no-store',
     headers: {
-      'Content-Type': 'application/json',
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
       'x-lingxiao-token': getServerToken(),
       ...(opts?.headers || {}),
     },
@@ -20,7 +21,7 @@ async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> {
   return body as T;
 }
 
-export default function McpServersTab() {
+export default function McpServersTab({ inline }: { inline?: boolean }) {
   const { t } = useTranslation();
   const sessionId = useSessionStore((s) => s.sessionId || s.activeSessionId);
   const [servers, setServers] = useState<McpServerConfig[]>([]);
@@ -102,7 +103,26 @@ export default function McpServersTab() {
       )}
 
       <div className="flex-1 overflow-y-auto">
-        {isLoading ? (
+        {creating ? (
+          <McpServerForm
+            inline={inline}
+            onClose={() => setCreating(false)}
+            onSaved={(server) => {
+              setCreating(false);
+              setServers((prev) => [...prev.filter((item) => item.id !== server.id), server].sort((a, b) => a.id.localeCompare(b.id)));
+            }}
+          />
+        ) : editing ? (
+          <McpServerForm
+            inline={inline}
+            initial={editing}
+            onClose={() => setEditing(null)}
+            onSaved={(server) => {
+              setEditing(null);
+              setServers((prev) => prev.map((item) => item.id === server.id ? server : item));
+            }}
+          />
+        ) : isLoading ? (
           <div className="flex items-center justify-center py-12">
             <Loader2 className="w-6 h-6 text-accent-brand animate-spin" />
           </div>
@@ -153,26 +173,6 @@ export default function McpServersTab() {
           </div>
         )}
       </div>
-
-      {creating && (
-        <McpServerForm
-          onClose={() => setCreating(false)}
-          onSaved={(server) => {
-            setCreating(false);
-            setServers((prev) => [...prev.filter((item) => item.id !== server.id), server].sort((a, b) => a.id.localeCompare(b.id)));
-          }}
-        />
-      )}
-      {editing && (
-        <McpServerForm
-          initial={editing}
-          onClose={() => setEditing(null)}
-          onSaved={(server) => {
-            setEditing(null);
-            setServers((prev) => prev.map((item) => item.id === server.id ? server : item));
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/web/src/components/settings/SettingsView.tsx
+++ b/web/src/components/settings/SettingsView.tsx
@@ -128,7 +128,7 @@ export default function SettingsView() {
             <Loader2 className="w-6 h-6 text-accent-brand animate-spin" />
           </div>
         ) : (
-          <div className="flex max-w-7xl flex-col gap-4 lg:flex-row">
+          <div className="flex max-w-7xl flex-col gap-4 lg:flex-row lg:items-start">
             <SettingsNav items={navItems} />
             <div className="min-w-0 flex-1 space-y-6">
               <ModelAndReasoningSection settings={settings} providers={providers} saveState={saveState} onSave={handleSave} onProvidersChange={setProviders} onRefreshSettings={fetchSettings} />

--- a/web/src/components/settings/sections/McpSection.tsx
+++ b/web/src/components/settings/sections/McpSection.tsx
@@ -21,7 +21,7 @@ export function McpSection({ settings, saveState, onSave }: { settings: Settings
       </SettingsRow>
       <div className="border-t border-border-default pt-3">
         <div className="h-[520px] border border-border-muted rounded overflow-hidden bg-bg-primary">
-          <McpServersTab />
+          <McpServersTab inline />
         </div>
       </div>
     </SettingsSection>

--- a/web/src/components/settings/sections/ModelAndReasoningSection.tsx
+++ b/web/src/components/settings/sections/ModelAndReasoningSection.tsx
@@ -26,6 +26,7 @@ import {
   Sparkles,
   Trash2,
   X,
+  Zap,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { SettingsSection } from '../components/SettingsSection';
@@ -63,6 +64,7 @@ export function ModelAndReasoningSection({
   const [newModel, setNewModel] = useState<AddModelForm>(() => createDefaultAddModelForm());
   const [addingModel, setAddingModel] = useState(false);
   const [modelStatus, setModelStatus] = useState<StatusMessage>(null);
+  const [cardTestResults, setCardTestResults] = useState<Record<string, StatusMessage>>({});
   const [showApiKey, setShowApiKey] = useState(false);
   const [leaderCtxEdit, setLeaderCtxEdit] = useState<number | ''>('');
   const [agentCtxEdit, setAgentCtxEdit] = useState<number | ''>('');
@@ -75,6 +77,7 @@ export function ModelAndReasoningSection({
   const [deletingModelId, setDeletingModelId] = useState<string | null>(null);
   const [editingModelId, setEditingModelId] = useState<string | null>(null);
   const [autoDetected, setAutoDetected] = useState(false);
+  const [testingModelId, setTestingModelId] = useState<string | null>(null);
 
   const configuredModels = useMemo<ModelItem[]>(
     () => providers.flatMap((p) => p.models.flatMap((m) => (m.provider ? [{ ...m, provider: m.provider }] : []))),
@@ -328,6 +331,47 @@ export function ModelAndReasoningSection({
     }
   };
 
+  const handleTestFormConnection = async () => {
+    const modelName = newModel.model.trim();
+    const apiKey = newModel.apiKey.trim();
+    if (!modelName || !apiKey) {
+      setModelStatus({ kind: 'error', message: t('settings.addModel.error.required') });
+      return;
+    }
+    setTestingModelId('__form__');
+    setModelStatus(null);
+    try {
+      await settingsApiFetch('/settings/test-llm', {
+        method: 'POST',
+        body: JSON.stringify({
+          provider: newModel.protocol,
+          apiKey,
+          baseUrl: newModel.baseUrl.trim(),
+          model: modelName,
+        }),
+      });
+      setModelStatus({ kind: 'success', message: t('onboarding.llm.testSuccess') });
+    } catch (e) {
+      setModelStatus({ kind: 'error', message: e instanceof Error ? e.message : t('onboarding.llm.testFailed') });
+    } finally {
+      setTestingModelId(null);
+    }
+  };
+
+  const handleTestCardConnection = async (modelId: string) => {
+    setTestingModelId(modelId);
+    setCardTestResults((prev) => ({ ...prev, [modelId]: null }));
+    try {
+      await settingsApiFetch(`/settings/test-model-provider/${encodeURIComponent(modelId)}`, { method: 'POST' });
+      setCardTestResults((prev) => ({ ...prev, [modelId]: { kind: 'success', message: t('onboarding.llm.testSuccess') } }));
+    } catch (e) {
+      setCardTestResults((prev) => ({ ...prev, [modelId]: { kind: 'error', message: e instanceof Error ? e.message : t('onboarding.llm.testFailed') } }));
+    } finally {
+      setTestingModelId(null);
+      setTimeout(() => setCardTestResults((prev) => ({ ...prev, [modelId]: null })), 4000);
+    }
+  };
+
   const effortOptions = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'adaptive'].map((value) => ({ value, label: t(`settings.effort.${value}`) }));
   const gatewayEnabled = !!settings.localLlmGatewayEnabled;
   const gatewayProvider = settingString(settings.localLlmGatewayProvider, 'openai');
@@ -488,6 +532,10 @@ export function ModelAndReasoningSection({
                 {addingModel ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
                 {existingModel ? t('settings.action.updateModel') : t('settings.addModel.save')}
               </button>
+              <button type="button" onClick={handleTestFormConnection} disabled={testingModelId === '__form__'} className="inline-flex min-h-8 items-center justify-center gap-1.5 rounded border border-border-default px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary disabled:opacity-50">
+                {testingModelId === '__form__' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Zap className="h-3.5 w-3.5" />}
+                {t('settings.git.testConnection')}
+              </button>
               {modelStatus && <StatusInline status={modelStatus} />}
             </div>
           </div>
@@ -552,8 +600,12 @@ export function ModelAndReasoningSection({
                   deleteDisabled={model.id === leaderModelId || model.id === agentModelId || model.id === gatewayConfiguredModelId}
                   deleteDisabledTitle={t('settings.model.deleteInUse')}
                   deleting={deletingModelId === model.id}
+                  testing={testingModelId === model.id}
+                  testLabel={t('settings.git.testConnection')}
+                  testResult={cardTestResults[model.id] ?? null}
                   onEdit={() => startEditModel(model)}
                   onDelete={() => setDeleteCandidate(model)}
+                  onTest={() => handleTestCardConnection(model.id)}
                 />
               ))}
             </div>
@@ -788,8 +840,12 @@ function ModelConfigCard({
   deleteDisabled,
   deleteDisabledTitle,
   deleting,
+  testing,
+  testLabel,
+  testResult,
   onEdit,
   onDelete,
+  onTest,
 }: {
   model: ModelItem;
   active: boolean;
@@ -800,8 +856,12 @@ function ModelConfigCard({
   deleteDisabled: boolean;
   deleteDisabledTitle: string;
   deleting: boolean;
+  testing: boolean;
+  testLabel: string;
+  testResult: StatusMessage;
   onEdit: () => void;
   onDelete: () => void;
+  onTest: () => void;
 }) {
   return (
     <div className="min-w-0 rounded-md border border-border-muted bg-bg-primary/45 p-3 transition-colors hover:border-accent-brand/40 hover:bg-bg-hover">
@@ -814,6 +874,16 @@ function ModelConfigCard({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={onTest}
+            disabled={testing}
+            className="inline-flex h-7 w-7 items-center justify-center rounded border border-border-default text-text-tertiary transition-colors hover:border-accent-brand/40 hover:bg-accent-brand/10 hover:text-accent-brand disabled:opacity-50"
+            title={testLabel}
+            aria-label={testLabel}
+          >
+            {testing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Zap className="h-3.5 w-3.5" />}
+          </button>
           <button
             type="button"
             onClick={onEdit}
@@ -843,6 +913,12 @@ function ModelConfigCard({
           <span>{formatNumber(model.contextWindowSize)} {tokenUnit}</span>
         </div>
       </div>
+      {testResult && (
+        <div className={`mt-2 flex items-center gap-1.5 rounded px-2 py-1 text-[11px] ${testResult.kind === 'success' ? 'bg-accent-green/10 text-accent-green' : 'bg-accent-red/10 text-accent-red'}`}>
+          {testResult.kind === 'success' ? <CheckCircle className="h-3 w-3" /> : <AlertCircle className="h-3 w-3" />}
+          {testResult.message}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -179,6 +179,70 @@
   border: 1px solid var(--color-border-muted);
 }
 
+/* ===== Docs 文档排版样式 ===== */
+.docs-prose {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.75;
+}
+.docs-prose h1 { font-size: 1.4rem; font-weight: 650; color: var(--color-text-primary); margin: 1.6em 0 0.5em; border-bottom: 1px solid var(--color-border-muted); padding-bottom: 0.3em; }
+.docs-prose h2 { font-size: 1.15rem; font-weight: 600; color: var(--color-text-primary); margin: 1.4em 0 0.4em; }
+.docs-prose h3 { font-size: 1rem; font-weight: 600; color: var(--color-text-primary); margin: 1.2em 0 0.3em; }
+.docs-prose p { margin-bottom: 0.75em; }
+.docs-prose ul, .docs-prose ol { padding-left: 1.5em; margin-bottom: 0.75em; }
+.docs-prose li { margin-bottom: 0.25em; }
+.docs-prose ul { list-style-type: disc; }
+.docs-prose ol { list-style-type: decimal; }
+.docs-prose strong { color: var(--color-text-primary); font-weight: 600; }
+.docs-prose a { color: var(--color-accent-brand); text-decoration: underline; text-underline-offset: 2px; }
+.docs-prose a:hover { opacity: 0.8; }
+.docs-prose code {
+  background: var(--color-bg-code);
+  border-radius: 3px;
+  padding: 0.15em 0.4em;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85em;
+  color: var(--color-accent-green);
+}
+.docs-prose pre {
+  background: var(--color-bg-code);
+  border: 1px solid var(--color-border-muted);
+  border-radius: 6px;
+  padding: 1em;
+  overflow-x: auto;
+  margin-bottom: 1em;
+}
+.docs-prose pre code { background: none; padding: 0; border-radius: 0; color: var(--color-text-secondary); }
+.docs-prose blockquote {
+  border-left: 3px solid var(--color-accent-brand);
+  padding-left: 1em;
+  margin: 0.8em 0;
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+.docs-prose table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-bottom: 1em;
+  font-size: 0.875rem;
+}
+.docs-prose th {
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  font-weight: 600;
+  text-align: left;
+  padding: 0.5em 0.75em;
+  border: 1px solid var(--color-border-muted);
+}
+.docs-prose td {
+  padding: 0.4em 0.75em;
+  border: 1px solid var(--color-border-muted);
+  vertical-align: top;
+}
+.docs-prose tr:nth-child(even) td { background: var(--color-bg-secondary); }
+.docs-prose hr { border: none; border-top: 1px solid var(--color-border-muted); margin: 1.5em 0; }
+.docs-prose img { max-width: 100%; border-radius: 4px; border: 1px solid var(--color-border-muted); }
+
 /* DOCX HTML 渲染专用样式（mammoth 输出可能带特殊元素） */
 .artifact-docx-prose {
   color: var(--color-text-secondary);


### PR DESCRIPTION
- Docs 面板：后端补全中文 title/content，前端移除独立语言切换，跟随全局 i18n，统一 docs-prose CSS 样式
- 模型设置：Add Model 表单和模型卡片各新增「测试连接」按钮，卡片结果独立展示
- MCP 服务器：添加/编辑表单改为内联渲染，取代全屏 overlay；修复 DELETE 请求空 body 报错
- 设置页：左侧导航栏粘性定位修复 (lg:items-start)