### PR TITLE
[codex] Reduce Dependabot update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,35 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
     labels:
       - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    groups:
+      root-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: npm
     directory: /web
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
     labels:
       - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    groups:
+      web-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Reduce Dependabot PR noise so dependency updates arrive in smaller, reviewable batches.

## Changes

- Limit open Dependabot version-update PRs to 2 per package ecosystem.
- Group root npm minor/patch updates into `root-minor-patch`.
- Group web npm minor/patch updates into `web-minor-patch`.
- Ignore semver-major version updates so major toolchain/provider upgrades are handled as explicit maintenance tasks.

## Current PR cleanup

Closed noisy Dependabot PRs that were major/cross-generation upgrades, had failing checks, or should be handled as grouped/manual upgrade work:

- #41 #40 #37 #36 #35 #33 #32 #31 #30 #29 #28 #26 #24

Kept lower-risk or paired updates for separate review:

- #42 unzipper patch
- #39/#38 Langfuse paired minor updates
- #34 @xyflow/react patch
- #27 React/@types React grouped update
- #25 proxy-agent patch

## Validation

- Reviewed current open Dependabot PRs and check status with `gh pr list` / `gh pr view`.
- Confirmed this PR only changes `.github/dependabot.yml`.
